### PR TITLE
Enables backwards compatibility (loading of 1.4.0.2 saves)

### DIFF
--- a/A3-Antistasi/functions.hpp
+++ b/A3-Antistasi/functions.hpp
@@ -57,6 +57,7 @@ class A3A
         class sellVehicle {file="sellVehicle.sqf";};
         class sizeMarker {file="sizeMarker.sqf";};
         class statistics {file="statistics.sqf";};
+        class translateVariable {file="statSave\translateVariable.sqf";};
         class keys {file="keys.sqf";};
         class timingCA {file="timingCA.sqf";};
         class undercover {file="undercover.sqf";};

--- a/A3-Antistasi/statSave/saveFuncs.sqf
+++ b/A3-Antistasi/statSave/saveFuncs.sqf
@@ -18,17 +18,40 @@ fn_SaveStat =
 
 fn_LoadStat =
 {
-	private ["_varName","_varvalue"];
+	private ["_varName","_varValue"];
 	_varName = _this select 0;
-	if (worldName == "Tanoa") then
-		{
-		_varValue = profileNameSpace getVariable (_varName + serverID + "WotP")
-		}
-	else
-		{
-		if (side group petros == independent) then {_varValue = profileNameSpace getVariable (_varName + serverID + "Antistasi" + worldName)} else {_varValue = profileNameSpace getVariable (_varName + serverID + "AntistasiB" + worldName)};
-		};
-	if(isNil "_varValue") exitWith {diag_log format ["Antistasi: Error en Persistent Load. La variable %1 no existe",_varname]};
+  
+  _loadVariable = {
+    private ["_varName","_varValue"];
+    _varName = _this select 0;
+    
+    //Return the value of this statement
+    if (worldName == "Tanoa") then
+      {
+      profileNameSpace getVariable (_varName + serverID + "WotP")
+      }
+    else
+      {
+      if (side group petros == independent) then 
+        {
+        profileNameSpace getVariable (_varName + serverID + "Antistasi" + worldName)
+        } 
+      else 
+        { 
+        profileNameSpace getVariable (_varName + serverID + "AntistasiB" + worldName)
+        };
+      };
+  };
+  
+  _varValue = [_varName] call _loadVariable;
+  
+  if(isNil "_varValue") then
+  {
+    _spanishVarName = [_varName] call A3A_fnc_translateVariable;
+    _varValue = [_spanishVarName] call _loadVariable;
+  };
+  
+	if(isNil "_varValue") exitWith {diag_log format ["Antistasi: Error during Persistent Load. The variable %1 does not exist", _varName]};
 	[_varName,_varValue] call fn_SetStat;
 };
 

--- a/A3-Antistasi/statSave/translateVariable.sqf
+++ b/A3-Antistasi/statSave/translateVariable.sqf
@@ -1,0 +1,38 @@
+params ["_englishNameToTranslate"];
+
+if (isNil "loadingTranslationTable" or {!(loadingTranslationTable getVariable ["loaded", false])}) then
+{
+  private _translationTable = [
+    ["miembros","membersX"],
+    ["dinero","moneyX"],
+    ["puestosFIA", "outpostsFIA"],
+    ["dificultad", "difficultyX"],
+    ["minas", "minesX"],
+    ["cuentaCA", "countCA"],
+    ["antenas", "antennas"],
+    ["fecha","dateX"],
+    ["distanciaSPWN","distanceSPWN"],
+    ["controlesSDK","controlsSDK"],
+    ["estaticas","staticsX"]
+  ];
+  
+  loadingTranslationTable = createSimpleObject ["Logic", [0, 0, 0]];
+  
+  {
+    _spanishName = _x select 0;
+    _englishName = _x select 1;
+    
+    loadingTranslationTable setVariable [_englishName, _spanishName, false];
+  } forEach _translationTable;
+  
+    loadingTranslationTable setVariable ["loaded", true]
+};
+
+private _result = loadingTranslationTable getVariable [_englishNameToTranslate, ObjNull];
+
+if (typeName _result != "STRING") then {
+  //diag_log ("Antistasi: No translation for " + _englishNameToTranslate);
+  _result = _englishNameToTranslate;
+};
+
+_result;


### PR DESCRIPTION
This enables the loading of untranslated (1.4.0.2) saves.

If loading a variable from the save fails, this looks up the original variable name, then attempts to load that value into the translated variable.

