### PR TITLE
Prevent duplicate markers breaking town init, provide error logs instead.

### DIFF
--- a/A3-Antistasi/Revive/handleDamage.sqf
+++ b/A3-Antistasi/Revive/handleDamage.sqf
@@ -25,16 +25,7 @@ if (_part == "") then
 					moveOut _unit;
 					};
 				_dam = 0.9;
-				if (isPlayer _unit) then {
-						_unit allowDamage false;
-						if (isPlayer _injurer) then {
-						[format["%1 was incapacitated by %2 (Friendly Fire)", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
-						diag_log format ["[Antistasi] %1 was incapacitaed by %2 (Friendly Fire)", name _unit, name _injurer];
-						}
-						else
-						{
-						[format["%1 was incapacitated", name _unit]] remoteExec ["systemChat", 0, false];
-						};
+				if (isPlayer _unit) then {_unit allowDamage false};
 				if (!isNull _injurer) then {[_unit,side _injurer] spawn A3A_fnc_unconscious} else {[_unit,sideUnknown] spawn A3A_fnc_unconscious};
 				}
 			else
@@ -48,8 +39,6 @@ if (_part == "") then
 						[_unit] spawn A3A_fnc_respawn;
 						if (isPlayer _injurer) then
 							{
-							[format["%1 was Team Killed by %2", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
-							diag_log format ["[Antistasi] %1 was Team Killed / Executed by %2", name _unit, name _injurer];
 							if (tkPunish) then
 								{
 								if ((_injurer != _unit) and (side _injurer == teamPlayer) and (_unit getVariable ["teamPlayer",false]) and (side group _unit == teamPlayer)) then
@@ -126,17 +115,7 @@ else
 							//_unit action ["getOut", vehicle _unit];
 							moveOut _unit;
 							};
-						if (isPlayer _unit) then {
-								_unit allowDamage false
-								if (isPlayer _injurer) then {
-								[format["%1 was incapacitated by %2 (Friendly Fire)", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
-								diag_log format ["[Antistasi] %1 was incapacitaed by %2 (Friendly Fire)", name _unit, name _injurer];
-								}
-								else
-								{
-								[format["%1 was incapacitated", name _unit]] remoteExec ["systemChat", 0, false];
-								};
-						};
+						if (isPlayer _unit) then {_unit allowDamage false};
 						if (!isNull _injurer) then {[_unit,side _injurer] spawn A3A_fnc_unconscious} else {[_unit,sideUnknown] spawn A3A_fnc_unconscious};
 						};
 					};
@@ -153,17 +132,7 @@ else
 							{
 							moveOut _unit;
 							};
-						if (isPlayer _unit) then {
-								_unit allowDamage false
-								if (isPlayer _injurer) then {
-								[format["%1 was incapacitated by %2 (Friendly Fire)", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
-								diag_log format ["[Antistasi] %1 was incapacitaed by %2 (Friendly Fire)", name _unit, name _injurer];
-								}
-								else
-								{
-								[format["%1 was incapacitated", name _unit]] remoteExec ["systemChat", 0, false];
-								};
-						};
+						if (isPlayer _unit) then {_unit allowDamage false};
 						if (!isNull _injurer) then {[_unit,side _injurer] spawn A3A_fnc_unconscious} else {[_unit,sideUnknown] spawn A3A_fnc_unconscious};
 						};
 					};

--- a/A3-Antistasi/Revive/handleDamage.sqf
+++ b/A3-Antistasi/Revive/handleDamage.sqf
@@ -127,7 +127,7 @@ else
 							moveOut _unit;
 							};
 						if (isPlayer _unit) then {
-								_unit allowDamage false
+								_unit allowDamage false;
 								if (isPlayer _injurer) then {
 								[format["%1 was incapacitated by %2 (Friendly Fire)", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
 								diag_log format ["[Antistasi] %1 was incapacitaed by %2 (Friendly Fire)", name _unit, name _injurer];
@@ -154,7 +154,7 @@ else
 							moveOut _unit;
 							};
 						if (isPlayer _unit) then {
-								_unit allowDamage false
+								_unit allowDamage false;
 								if (isPlayer _injurer) then {
 								[format["%1 was incapacitated by %2 (Friendly Fire)", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
 								diag_log format ["[Antistasi] %1 was incapacitaed by %2 (Friendly Fire)", name _unit, name _injurer];

--- a/A3-Antistasi/Revive/handleDamage.sqf
+++ b/A3-Antistasi/Revive/handleDamage.sqf
@@ -25,7 +25,16 @@ if (_part == "") then
 					moveOut _unit;
 					};
 				_dam = 0.9;
-				if (isPlayer _unit) then {_unit allowDamage false};
+				if (isPlayer _unit) then {
+						_unit allowDamage false;
+						if (isPlayer _injurer) then {
+						[format["%1 was incapacitated by %2 (Friendly Fire)", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
+						diag_log format ["[Antistasi] %1 was incapacitaed by %2 (Friendly Fire)", name _unit, name _injurer];
+						}
+						else
+						{
+						[format["%1 was incapacitated", name _unit]] remoteExec ["systemChat", 0, false];
+						};
 				if (!isNull _injurer) then {[_unit,side _injurer] spawn A3A_fnc_unconscious} else {[_unit,sideUnknown] spawn A3A_fnc_unconscious};
 				}
 			else
@@ -39,6 +48,8 @@ if (_part == "") then
 						[_unit] spawn A3A_fnc_respawn;
 						if (isPlayer _injurer) then
 							{
+							[format["%1 was Team Killed by %2", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
+							diag_log format ["[Antistasi] %1 was Team Killed / Executed by %2", name _unit, name _injurer];
 							if (tkPunish) then
 								{
 								if ((_injurer != _unit) and (side _injurer == teamPlayer) and (_unit getVariable ["teamPlayer",false]) and (side group _unit == teamPlayer)) then
@@ -115,7 +126,17 @@ else
 							//_unit action ["getOut", vehicle _unit];
 							moveOut _unit;
 							};
-						if (isPlayer _unit) then {_unit allowDamage false};
+						if (isPlayer _unit) then {
+								_unit allowDamage false
+								if (isPlayer _injurer) then {
+								[format["%1 was incapacitated by %2 (Friendly Fire)", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
+								diag_log format ["[Antistasi] %1 was incapacitaed by %2 (Friendly Fire)", name _unit, name _injurer];
+								}
+								else
+								{
+								[format["%1 was incapacitated", name _unit]] remoteExec ["systemChat", 0, false];
+								};
+						};
 						if (!isNull _injurer) then {[_unit,side _injurer] spawn A3A_fnc_unconscious} else {[_unit,sideUnknown] spawn A3A_fnc_unconscious};
 						};
 					};
@@ -132,7 +153,17 @@ else
 							{
 							moveOut _unit;
 							};
-						if (isPlayer _unit) then {_unit allowDamage false};
+						if (isPlayer _unit) then {
+								_unit allowDamage false
+								if (isPlayer _injurer) then {
+								[format["%1 was incapacitated by %2 (Friendly Fire)", name _unit, name _injurer]] remoteExec ["systemChat", 0, false];
+								diag_log format ["[Antistasi] %1 was incapacitaed by %2 (Friendly Fire)", name _unit, name _injurer];
+								}
+								else
+								{
+								[format["%1 was incapacitated", name _unit]] remoteExec ["systemChat", 0, false];
+								};
+						};
 						if (!isNull _injurer) then {[_unit,side _injurer] spawn A3A_fnc_unconscious} else {[_unit,sideUnknown] spawn A3A_fnc_unconscious};
 						};
 					};

--- a/A3-Antistasi/initZones.sqf
+++ b/A3-Antistasi/initZones.sqf
@@ -153,36 +153,25 @@ if ((_nameX != "") and (_nameX != "Lakatoro01") and (_nameX != "Galili01") and (
     _nroads = count _roads;
     _nearRoadsFinalSorted = [_roads, [], { _pos distance _x }, "ASCEND"] call BIS_fnc_sortBy;
     _pos = _nearRoadsFinalSorted select 0;
-    if (isNil "_pos") then {diag_log format ["[Antistasi] Failed to create town at %1 - Position given was Nil ",_nameX];
-	}
-	else
-		{
-		if (isNil {server getVariable _nameX}) then
-			{
-			_mrk = createmarker [format ["%1", _nameX], _pos];
-			_mrk setMarkerSize [_size, _size];
-			_mrk setMarkerShape "RECTANGLE";
-			_mrk setMarkerBrush "SOLID";
-			_mrk setMarkerColor colorOccupants;
-			_mrk setMarkerText _nameX;
-			_mrk setMarkerAlpha 0;
-			citiesX pushBack _nameX;
-			spawner setVariable [_nameX,2,true];
-			_dmrk = createMarker [format ["Dum%1",_nameX], _pos];
-			_dmrk setMarkerShape "ICON";
-			_dmrk setMarkerType "loc_Ruin";
-			_dmrk setMarkerColor colorOccupants;
-			if (_nroads < _numVeh) then {_numVeh = _nroads};
-			sidesX setVariable [_mrk,Occupants,true];
-			_info = [_numCiv, _numVeh, prestigeOPFOR,prestigeBLUFOR];
-			server setVariable [_nameX,_info,true];
-			}
-			else
-			{
-			diag_log format ["[Antistasi] Failed to create town at %1 - Town Already exists ",_nameX];
-			};
-		};
-	};
+    if (isNil "_pos") then {diag_log format ["Falla %1",_nameX]};
+    _mrk = createmarker [format ["%1", _nameX], _pos];
+    _mrk setMarkerSize [_size, _size];
+    _mrk setMarkerShape "RECTANGLE";
+    _mrk setMarkerBrush "SOLID";
+    _mrk setMarkerColor colorOccupants;
+    _mrk setMarkerText _nameX;
+    _mrk setMarkerAlpha 0;
+    citiesX pushBack _nameX;
+    spawner setVariable [_nameX,2,true];
+    _dmrk = createMarker [format ["Dum%1",_nameX], _pos];
+    _dmrk setMarkerShape "ICON";
+    _dmrk setMarkerType "loc_Ruin";
+    _dmrk setMarkerColor colorOccupants;
+    if (_nroads < _numVeh) then {_numVeh = _nroads};
+    sidesX setVariable [_mrk,Occupants,true];
+    _info = [_numCiv, _numVeh, prestigeOPFOR,prestigeBLUFOR];
+    server setVariable [_nameX,_info,true];
+    };
 }foreach (nearestLocations [getArray (configFile >> "CfgWorlds" >> worldName >> "centerPosition"), ["NameCityCapital","NameCity","NameVillage","CityCenter"], 25000]);
 
 markersX = markersX + citiesX;

--- a/A3-Antistasi/initZones.sqf
+++ b/A3-Antistasi/initZones.sqf
@@ -153,25 +153,36 @@ if ((_nameX != "") and (_nameX != "Lakatoro01") and (_nameX != "Galili01") and (
     _nroads = count _roads;
     _nearRoadsFinalSorted = [_roads, [], { _pos distance _x }, "ASCEND"] call BIS_fnc_sortBy;
     _pos = _nearRoadsFinalSorted select 0;
-    if (isNil "_pos") then {diag_log format ["Falla %1",_nameX]};
-    _mrk = createmarker [format ["%1", _nameX], _pos];
-    _mrk setMarkerSize [_size, _size];
-    _mrk setMarkerShape "RECTANGLE";
-    _mrk setMarkerBrush "SOLID";
-    _mrk setMarkerColor colorOccupants;
-    _mrk setMarkerText _nameX;
-    _mrk setMarkerAlpha 0;
-    citiesX pushBack _nameX;
-    spawner setVariable [_nameX,2,true];
-    _dmrk = createMarker [format ["Dum%1",_nameX], _pos];
-    _dmrk setMarkerShape "ICON";
-    _dmrk setMarkerType "loc_Ruin";
-    _dmrk setMarkerColor colorOccupants;
-    if (_nroads < _numVeh) then {_numVeh = _nroads};
-    sidesX setVariable [_mrk,Occupants,true];
-    _info = [_numCiv, _numVeh, prestigeOPFOR,prestigeBLUFOR];
-    server setVariable [_nameX,_info,true];
+    if (isNil "_pos") then {diag_log format ["[Antistasi] Failed to create town at %1 - Position given was Nil ",_nameX];
+    }
+    else
+    {
+     if (isNil {server getVariable _nameX}) then
+	  {
+      _mrk = createmarker [format ["%1", _nameX], _pos];
+      _mrk setMarkerSize [_size, _size];
+      _mrk setMarkerShape "RECTANGLE";
+      _mrk setMarkerBrush "SOLID";
+      _mrk setMarkerColor colorOccupants;
+      _mrk setMarkerText _nameX;
+      _mrk setMarkerAlpha 0;
+      citiesX pushBack _nameX;
+      spawner setVariable [_nameX,2,true];
+      _dmrk = createMarker [format ["Dum%1",_nameX], _pos];
+      _dmrk setMarkerShape "ICON";
+      _dmrk setMarkerType "loc_Ruin";
+      _dmrk setMarkerColor colorOccupants;
+      if (_nroads < _numVeh) then {_numVeh = _nroads};
+      sidesX setVariable [_mrk,Occupants,true];
+      _info = [_numCiv, _numVeh, prestigeOPFOR,prestigeBLUFOR];
+      server setVariable [_nameX,_info,true];
+      }
+      else
+      {
+      diag_log format ["[Antistasi] Failed to create town at %1 - Town already exists ",_nameX];
+      };
     };
+};
 }foreach (nearestLocations [getArray (configFile >> "CfgWorlds" >> worldName >> "centerPosition"), ["NameCityCapital","NameCity","NameVillage","CityCenter"], 25000]);
 
 markersX = markersX + citiesX;

--- a/A3-Antistasi/initZones.sqf
+++ b/A3-Antistasi/initZones.sqf
@@ -153,25 +153,36 @@ if ((_nameX != "") and (_nameX != "Lakatoro01") and (_nameX != "Galili01") and (
     _nroads = count _roads;
     _nearRoadsFinalSorted = [_roads, [], { _pos distance _x }, "ASCEND"] call BIS_fnc_sortBy;
     _pos = _nearRoadsFinalSorted select 0;
-    if (isNil "_pos") then {diag_log format ["Falla %1",_nameX]};
-    _mrk = createmarker [format ["%1", _nameX], _pos];
-    _mrk setMarkerSize [_size, _size];
-    _mrk setMarkerShape "RECTANGLE";
-    _mrk setMarkerBrush "SOLID";
-    _mrk setMarkerColor colorOccupants;
-    _mrk setMarkerText _nameX;
-    _mrk setMarkerAlpha 0;
-    citiesX pushBack _nameX;
-    spawner setVariable [_nameX,2,true];
-    _dmrk = createMarker [format ["Dum%1",_nameX], _pos];
-    _dmrk setMarkerShape "ICON";
-    _dmrk setMarkerType "loc_Ruin";
-    _dmrk setMarkerColor colorOccupants;
-    if (_nroads < _numVeh) then {_numVeh = _nroads};
-    sidesX setVariable [_mrk,Occupants,true];
-    _info = [_numCiv, _numVeh, prestigeOPFOR,prestigeBLUFOR];
-    server setVariable [_nameX,_info,true];
-    };
+    if (isNil "_pos") then {diag_log format ["[Antistasi] Failed to create town at %1 - Position given was Nil ",_nameX];
+	}
+	else
+		{
+		if (isNil {server getVariable _nameX}) then
+			{
+			_mrk = createmarker [format ["%1", _nameX], _pos];
+			_mrk setMarkerSize [_size, _size];
+			_mrk setMarkerShape "RECTANGLE";
+			_mrk setMarkerBrush "SOLID";
+			_mrk setMarkerColor colorOccupants;
+			_mrk setMarkerText _nameX;
+			_mrk setMarkerAlpha 0;
+			citiesX pushBack _nameX;
+			spawner setVariable [_nameX,2,true];
+			_dmrk = createMarker [format ["Dum%1",_nameX], _pos];
+			_dmrk setMarkerShape "ICON";
+			_dmrk setMarkerType "loc_Ruin";
+			_dmrk setMarkerColor colorOccupants;
+			if (_nroads < _numVeh) then {_numVeh = _nroads};
+			sidesX setVariable [_mrk,Occupants,true];
+			_info = [_numCiv, _numVeh, prestigeOPFOR,prestigeBLUFOR];
+			server setVariable [_nameX,_info,true];
+			}
+			else
+			{
+			diag_log format ["[Antistasi] Failed to create town at %1 - Town Already exists ",_nameX];
+			};
+		};
+	};
 }foreach (nearestLocations [getArray (configFile >> "CfgWorlds" >> worldName >> "centerPosition"), ["NameCityCapital","NameCity","NameVillage","CityCenter"], 25000]);
 
 markersX = markersX + citiesX;


### PR DESCRIPTION
If _pos is nil then why still try to create the marker? instead log error. If town already exists don't try to duplicate (spams script errors, variable already exists), instead log error. Helps with map porting and doesn't affect Altis, Tanoa or Chernarus.