### PR TITLE
Added breach script for testing

### DIFF
--- a/A3-Antistasi/CREATE/AIVEHinit.sqf
+++ b/A3-Antistasi/CREATE/AIVEHinit.sqf
@@ -8,7 +8,9 @@ if ((_veh isKindOf "FlagCarrier") or (_veh isKindOf "Building") or (_veh isKindO
 _typeX = typeOf _veh;
 
 if ((_typeX in vehNormal) or (_typeX in vehAttack) or (_typeX in vehBoats)) then
-	{
+{
+	_veh addAction ["Breach Vehicle", {[_this select 0, _this select 1, _this select 2] execVM "breachVehicle.sqf"},nil,4,false,true,"","(isPlayer _this) && (_this == vehicle _this)",5];
+
 	_veh addEventHandler ["Killed",
 		{
 		private _veh = _this select 0;

--- a/A3-Antistasi/breachVehicle.sqf
+++ b/A3-Antistasi/breachVehicle.sqf
@@ -1,0 +1,154 @@
+params["_vehicle", "_caller", "_actionID"];
+
+if(!isPlayer _caller) exitWith {hint "Only players are currently able to breach vehicles!";};
+
+//Only engineers should be able to breach a vehicle
+_isEngineer = _caller getUnitTrait "engineer";
+if(!_isEngineer) exitWith {hint "You have to be an engineer to breach open a vehicle!";};
+
+if(!alive _vehicle) exitWith {hint "Why would you want to breach open a destroyed vehicle?"; _vehicle removeAction _actionID;};
+
+_isAPC = (typeOf _vehicle) in vehAPCs;
+_isTank = (typeOf _vehicle) in vehTanks;
+
+if(_isAPC && !("DemoCharge_Remote_Mag" in (magazines _caller))) exitWith {hint "You need a explosive charge to breach an APCs open!"};
+if(_isTank && !("SatchelCharge_Remote_Mag" in (magazines _caller))) exitWith {hint "You need a explosive satchel to breach a tank open!"};
+
+_time = 15 + (random 5);
+if(_isAPC) then
+{
+  _time = 25 + (random 10);
+};
+if(_isTank) then
+{
+  _time = 45 + (random 15);
+};
+
+_caller setVariable ["timeToHeal",time + _time];
+_caller playMoveNow selectRandom medicAnims;
+_caller setVariable ["breachVeh", _vehicle];
+_caller setVariable ["animsDone",false];
+_caller setVariable ["cancelBreach",false];
+
+_action = _caller addAction ["Cancel Breaching", {(_this select 1) setVariable ["cancelBreach",true]},nil,6,true,true,"","(isPlayer _this)"];
+_vehicle removeAction _actionID;
+
+_caller addEventHandler ["AnimDone",
+{
+	private _caller = _this select 0;
+  private _vehicle = _caller getVariable "breachVeh";
+	if
+  (
+    (alive _vehicle) &&
+    {(_caller == vehicle _caller) &&
+    {(_caller distance _vehicle < 8) &&
+    {([_caller] call A3A_fnc_canFight) &&
+    {(time <= (_caller getVariable ["timeToHeal",time])) &&
+    {!(_caller getVariable ["cancelBreach",false])}}}}}
+  ) then
+	{
+		_caller playMoveNow selectRandom medicAnims;
+	}
+	else
+	{
+		_caller removeEventHandler ["AnimDone",_thisEventHandler];
+		_caller setVariable ["animsDone",true];
+	};
+}];
+
+//Wait for anims to finish
+waitUntil {sleep 0.5; (_caller getVariable ["animsDone",false])};
+
+_caller setVariable ["breachVeh", objNull];
+_caller removeAction _action;
+
+if
+(
+  !alive _vehicle ||
+  {_caller != vehicle _caller || //TODO there was something about that on the optimisation page, look it up
+  {_caller distance _vehicle >= 8 ||
+  {!([_caller] call A3A_fnc_canFight) ||
+  {_caller getVariable ["cancelBreach",false]}}}}
+) exitWith
+{
+	hint "Breaching cancelled";
+  _caller setVariable ["cancelBreach",nil];
+  if(alive _vehicle) then {_vehicle addAction ["Breach Vehicle", {[_this select 0, _this select 1, _this select 2] execVM "breachVehicle.sqf"},nil,4,false,true,"","(isPlayer _this)",5];};
+};
+
+_damageDealt = 0;
+if(_isAPC) then
+{
+  _caller removeMagazine "DemoCharge_Remote_Mag";
+  _damageDealt = 0.15 + random 0.15;
+};
+
+if(_isTank) then
+{
+  _caller removeMagazine "SatchelCharge_Remote_Mag";
+  _damageDealt = 0.25 + random 0.25;
+};
+
+_currentDamage = _vehicle getHit (getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitPoints" >> "HitHull" >> "name"));
+_result = _currentDamage + _damageDealt;
+if(_result > 1) then {_result = 1};
+_vehicle setHit [getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitPoints" >> "HitHull" >> "name"), _result];
+
+_currentDamage = _vehicle getHitPointDamage (getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitFuel" >> "HitHull" >> "name"));
+_result = _currentDamage + _damageDealt;
+if(_result > 1) then {_result = 1};
+_vehicle setHit [getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitPoints" >> "HitFuel" >> "name"), _result];
+
+_currentDamage = _vehicle getHitPointDamage (getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitEngine" >> "HitHull" >> "name"));
+_result = _currentDamage + _damageDealt;
+if(_result > 1) then {_result = 1};
+_vehicle setHit [getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitPoints" >> "HitEngine" >> "name"), _result];
+
+_currentDamage = _vehicle getHitPointDamage (getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitPoints" >> "HitBody" >> "name"));
+_result = _currentDamage + _damageDealt;
+if(_result > 1) then {_result = 1};
+_vehicle setHit [getText(configFile >> "CfgVehicles" >> (typeOf _vehicle) >> "HitPoints" >> "HitBody" >> "name"), _result];
+
+if(((damage _vehicle) + _damageDealt) > 0.9) exitWith
+{
+  _bomb = "SatchelCharge_Remote_Ammo_Scripted" createVehicle (getPos _vehicle);
+  _bomb setDamage 1;
+  _vehicle setDamage 1;
+};
+
+playSound3D [ "A3\Sounds_F\environment\ambient\battlefield\battlefield_explosions3.wss", _vehicle, false, (getPos _vehicle), 4, 1, 0 ];
+
+sleep 0.5;
+_vehicle lock 0;
+
+_crew = crew _vehicle;
+{
+    if(random 10 > 7) then
+    {
+      _x setDamage 1;
+    };
+    if(alive _X) then
+    {
+      moveOut _x;
+      _x setVariable ["surrendered",true,true];
+      [_x] spawn A3A_fnc_surrenderAction;
+    }
+    else
+    {
+      _dropPos = _vehicle getRelPos [5, random 360];
+      _X setPos _dropPos;
+    };
+} forEach _crew;
+
+if((_isAPC && {(typeOf _vehicle) in vehNATOAPC}) || {_isTank && {(typeOf _vehicle) in vehNATOTank}}) then
+{
+  [1,0] remoteExec ["A3A_fnc_prestige",2];
+  if(citiesX findIf {(getMarkerPos _x) distance _vehicle < 300} != -1) then
+  {
+    [-1, 1, getPos _vehicle] remoteExec ["A3A_fnc_citySupportChange",2];
+  };
+}
+else
+{
+  [0,1] remoteExec ["A3A_fnc_prestige",2];
+};


### PR DESCRIPTION
Adds a small feature, that lets engineers breach open armored vehicles with explosives. Duration, needed explosive and damage dealt to vehicle depends on the vehicle. APCs need 40 sec, one explosive charge and get a damage of max 30%. Tanks need 60 sec, one explosive satchel and get a damage of max 50%. Cancelling the action cost nothings and deals no damage. If the vehicle is already damaged and the breach operation exceeds 100% damage, the vehicle will blow up with a combined explosion of the explosive.

On success, the explosion sound will play and the remaining crew will have a chance to die. All surviving crew member will exit and surrender (Dont panik and shoot them). The vehicle will be unlocked at this point.

There is currently no smoke produced by the breach process as partical effects are crazy compicated.

It is tested in SP and MP with spawned in vehicles. There may be bugs, but the biggest ones should be fixes. Untested what happens if you try this undercover.

There are a few improvements I could do, but as it is not safe that this will be feature of the official version, this should do it as a alpha version.

Breached vehicles will look like this
![20190806135838_1](https://user-images.githubusercontent.com/31988396/62540220-6785d380-b857-11e9-959c-620072779fab.jpg)
